### PR TITLE
Encrypt bank API secrets and disable autoload

### DIFF
--- a/husfelag-bokhald/includes/admin-bank-api.php
+++ b/husfelag-bokhald/includes/admin-bank-api.php
@@ -3,6 +3,26 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+// Dulkóðunar hjálparföll
+if (!function_exists('hb_encrypt_secret')) {
+    function hb_encrypt_secret($data) {
+        $key = substr(wp_salt('auth'), 0, 32);
+        $iv = openssl_random_pseudo_bytes(16);
+        $encrypted = openssl_encrypt($data, 'AES-256-CBC', $key, 0, $iv);
+        return base64_encode($iv . $encrypted);
+    }
+}
+
+if (!function_exists('hb_decrypt_secret')) {
+    function hb_decrypt_secret($data) {
+        $key = substr(wp_salt('auth'), 0, 32);
+        $data = base64_decode($data);
+        $iv = substr($data, 0, 16);
+        $encrypted = substr($data, 16);
+        return openssl_decrypt($encrypted, 'AES-256-CBC', $key, 0, $iv);
+    }
+}
+
 // Öryggisathugun
 if (!current_user_can('manage_options')) {
     wp_die(__('Þú hefur ekki heimild til þessa.', 'husfelag-bokhald'));
@@ -12,13 +32,14 @@ if (!current_user_can('manage_options')) {
 if (isset($_POST['hb_save_bank_settings']) && wp_verify_nonce($_POST['hb_nonce'], 'hb_save_bank_settings') && current_user_can('manage_options')) {
     $bank = sanitize_text_field($_POST['selected_bank']);
     $client_id = sanitize_text_field($_POST['client_id']);
-    $client_secret = sanitize_text_field($_POST['client_secret']);
+    $client_secret_raw = sanitize_text_field($_POST['client_secret']);
+    $client_secret = hb_encrypt_secret($client_secret_raw);
     $account_id = sanitize_text_field($_POST['account_id']);
-    
-    update_option('hb_selected_bank', $bank);
-    update_option('hb_' . $bank . '_client_id', $client_id);
-    update_option('hb_' . $bank . '_client_secret', $client_secret);
-    update_option('hb_bank_account_id', $account_id);
+
+    update_option('hb_selected_bank', $bank, false);
+    update_option('hb_' . $bank . '_client_id', $client_id, false);
+    update_option('hb_' . $bank . '_client_secret', $client_secret, false);
+    update_option('hb_bank_account_id', $account_id, false);
     
     echo '<div class="notice notice-success"><p>API stillingar vistaðar!</p></div>';
 }
@@ -108,7 +129,8 @@ if (isset($_POST['hb_sync_transactions']) && wp_verify_nonce($_POST['hb_nonce'],
 // Núverandi stillingar
 $selected_bank = get_option('hb_selected_bank', '');
 $client_id = get_option('hb_' . $selected_bank . '_client_id', '');
-$client_secret = get_option('hb_' . $selected_bank . '_client_secret', '');
+$client_secret_encrypted = get_option('hb_' . $selected_bank . '_client_secret', '');
+$client_secret = $client_secret_encrypted ? hb_decrypt_secret($client_secret_encrypted) : '';
 $account_id = get_option('hb_bank_account_id', '');
 
 $available_banks = array(

--- a/husfelag-bokhald/includes/api/bank-api-client.php
+++ b/husfelag-bokhald/includes/api/bank-api-client.php
@@ -8,6 +8,26 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+// Dulkóðunar hjálparföll
+if (!function_exists('hb_encrypt_secret')) {
+    function hb_encrypt_secret($data) {
+        $key = substr(wp_salt('auth'), 0, 32);
+        $iv = openssl_random_pseudo_bytes(16);
+        $encrypted = openssl_encrypt($data, 'AES-256-CBC', $key, 0, $iv);
+        return base64_encode($iv . $encrypted);
+    }
+}
+
+if (!function_exists('hb_decrypt_secret')) {
+    function hb_decrypt_secret($data) {
+        $key = substr(wp_salt('auth'), 0, 32);
+        $data = base64_decode($data);
+        $iv = substr($data, 0, 16);
+        $encrypted = substr($data, 16);
+        return openssl_decrypt($encrypted, 'AES-256-CBC', $key, 0, $iv);
+    }
+}
+
 class HB_Bank_API_Client {
     
     private $bank_config;
@@ -53,7 +73,8 @@ class HB_Bank_API_Client {
         
         // Sækja stillingar úr WordPress options
         $this->bank_config['client_id'] = get_option('hb_' . $bank_code . '_client_id', '');
-        $this->bank_config['client_secret'] = get_option('hb_' . $bank_code . '_client_secret', '');
+        $encrypted_secret = get_option('hb_' . $bank_code . '_client_secret', '');
+        $this->bank_config['client_secret'] = $encrypted_secret ? hb_decrypt_secret($encrypted_secret) : '';
         
         if (empty($this->bank_config['client_id']) || empty($this->bank_config['client_secret'])) {
             throw new Exception('API stillingar vantar fyrir ' . $this->bank_config['name']);
@@ -139,7 +160,7 @@ class HB_Bank_API_Client {
         $this->consent_id = $response_body['consentId'];
         
         // Vista consent ID
-        update_option('hb_bank_consent_id', $this->consent_id);
+        update_option('hb_bank_consent_id', $this->consent_id, false);
         
         return $response_body;
     }

--- a/wordpress/wp-content/plugins/husfelag-bokhald/includes/admin-bank-api.php
+++ b/wordpress/wp-content/plugins/husfelag-bokhald/includes/admin-bank-api.php
@@ -3,6 +3,26 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+// Dulkóðunar hjálparföll
+if (!function_exists('hb_encrypt_secret')) {
+    function hb_encrypt_secret($data) {
+        $key = substr(wp_salt('auth'), 0, 32);
+        $iv = openssl_random_pseudo_bytes(16);
+        $encrypted = openssl_encrypt($data, 'AES-256-CBC', $key, 0, $iv);
+        return base64_encode($iv . $encrypted);
+    }
+}
+
+if (!function_exists('hb_decrypt_secret')) {
+    function hb_decrypt_secret($data) {
+        $key = substr(wp_salt('auth'), 0, 32);
+        $data = base64_decode($data);
+        $iv = substr($data, 0, 16);
+        $encrypted = substr($data, 16);
+        return openssl_decrypt($encrypted, 'AES-256-CBC', $key, 0, $iv);
+    }
+}
+
 // Öryggisathugun
 if (!current_user_can('manage_options')) {
     wp_die(__('Þú hefur ekki heimild til þessa.', 'husfelag-bokhald'));
@@ -12,13 +32,14 @@ if (!current_user_can('manage_options')) {
 if (isset($_POST['hb_save_bank_settings']) && wp_verify_nonce($_POST['hb_nonce'], 'hb_save_bank_settings') && current_user_can('manage_options')) {
     $bank = sanitize_text_field($_POST['selected_bank']);
     $client_id = sanitize_text_field($_POST['client_id']);
-    $client_secret = sanitize_text_field($_POST['client_secret']);
+    $client_secret_raw = sanitize_text_field($_POST['client_secret']);
+    $client_secret = hb_encrypt_secret($client_secret_raw);
     $account_id = sanitize_text_field($_POST['account_id']);
-    
-    update_option('hb_selected_bank', $bank);
-    update_option('hb_' . $bank . '_client_id', $client_id);
-    update_option('hb_' . $bank . '_client_secret', $client_secret);
-    update_option('hb_bank_account_id', $account_id);
+
+    update_option('hb_selected_bank', $bank, false);
+    update_option('hb_' . $bank . '_client_id', $client_id, false);
+    update_option('hb_' . $bank . '_client_secret', $client_secret, false);
+    update_option('hb_bank_account_id', $account_id, false);
     
     echo '<div class="notice notice-success"><p>API stillingar vistaðar!</p></div>';
 }
@@ -108,7 +129,8 @@ if (isset($_POST['hb_sync_transactions']) && wp_verify_nonce($_POST['hb_nonce'],
 // Núverandi stillingar
 $selected_bank = get_option('hb_selected_bank', '');
 $client_id = get_option('hb_' . $selected_bank . '_client_id', '');
-$client_secret = get_option('hb_' . $selected_bank . '_client_secret', '');
+$client_secret_encrypted = get_option('hb_' . $selected_bank . '_client_secret', '');
+$client_secret = $client_secret_encrypted ? hb_decrypt_secret($client_secret_encrypted) : '';
 $account_id = get_option('hb_bank_account_id', '');
 
 $available_banks = array(

--- a/wordpress/wp-content/plugins/husfelag-bokhald/includes/api/bank-api-client.php
+++ b/wordpress/wp-content/plugins/husfelag-bokhald/includes/api/bank-api-client.php
@@ -8,6 +8,26 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+// Dulkóðunar hjálparföll
+if (!function_exists('hb_encrypt_secret')) {
+    function hb_encrypt_secret($data) {
+        $key = substr(wp_salt('auth'), 0, 32);
+        $iv = openssl_random_pseudo_bytes(16);
+        $encrypted = openssl_encrypt($data, 'AES-256-CBC', $key, 0, $iv);
+        return base64_encode($iv . $encrypted);
+    }
+}
+
+if (!function_exists('hb_decrypt_secret')) {
+    function hb_decrypt_secret($data) {
+        $key = substr(wp_salt('auth'), 0, 32);
+        $data = base64_decode($data);
+        $iv = substr($data, 0, 16);
+        $encrypted = substr($data, 16);
+        return openssl_decrypt($encrypted, 'AES-256-CBC', $key, 0, $iv);
+    }
+}
+
 class HB_Bank_API_Client {
     
     private $bank_config;
@@ -53,7 +73,8 @@ class HB_Bank_API_Client {
         
         // Sækja stillingar úr WordPress options
         $this->bank_config['client_id'] = get_option('hb_' . $bank_code . '_client_id', '');
-        $this->bank_config['client_secret'] = get_option('hb_' . $bank_code . '_client_secret', '');
+        $encrypted_secret = get_option('hb_' . $bank_code . '_client_secret', '');
+        $this->bank_config['client_secret'] = $encrypted_secret ? hb_decrypt_secret($encrypted_secret) : '';
         
         if (empty($this->bank_config['client_id']) || empty($this->bank_config['client_secret'])) {
             throw new Exception('API stillingar vantar fyrir ' . $this->bank_config['name']);
@@ -139,7 +160,7 @@ class HB_Bank_API_Client {
         $this->consent_id = $response_body['consentId'];
         
         // Vista consent ID
-        update_option('hb_bank_consent_id', $this->consent_id);
+        update_option('hb_bank_consent_id', $this->consent_id, false);
         
         return $response_body;
     }


### PR DESCRIPTION
## Summary
- Avoid autoloading plugin options for bank settings
- Encrypt bank API `client_secret` when stored and decrypt on use
- Apply same security adjustments to API client helper

## Testing
- `php -l husfelag-bokhald/includes/admin-bank-api.php`
- `php -l husfelag-bokhald/includes/api/bank-api-client.php`
- `php -l wordpress/wp-content/plugins/husfelag-bokhald/includes/admin-bank-api.php`
- `php -l wordpress/wp-content/plugins/husfelag-bokhald/includes/api/bank-api-client.php`


------
https://chatgpt.com/codex/tasks/task_e_6894a1dee1f88322870a411652c3e4d7