### PR TITLE
Sanitize nonce before verification

### DIFF
--- a/husfelag-bokhald/includes/security-functions.php
+++ b/husfelag-bokhald/includes/security-functions.php
@@ -132,7 +132,8 @@ function hb_check_rate_limit($action, $limit = 10, $window = 300) {
  * Validate CSRF token
  */
 function hb_verify_request($action = 'husfelag_ajax_nonce') {
-    if (!wp_verify_nonce($_REQUEST['nonce'] ?? '', $action)) {
+    $nonce = sanitize_text_field($_REQUEST['nonce'] ?? '');
+    if (!wp_verify_nonce($nonce, $action)) {
         hb_log_security_event('Invalid nonce', "Action: $action");
         return false;
     }

--- a/wordpress/wp-content/plugins/husfelag-bokhald/includes/security-functions.php
+++ b/wordpress/wp-content/plugins/husfelag-bokhald/includes/security-functions.php
@@ -132,7 +132,8 @@ function hb_check_rate_limit($action, $limit = 10, $window = 300) {
  * Validate CSRF token
  */
 function hb_verify_request($action = 'husfelag_ajax_nonce') {
-    if (!wp_verify_nonce($_REQUEST['nonce'] ?? '', $action)) {
+    $nonce = sanitize_text_field($_REQUEST['nonce'] ?? '');
+    if (!wp_verify_nonce($nonce, $action)) {
         hb_log_security_event('Invalid nonce', "Action: $action");
         return false;
     }


### PR DESCRIPTION
## Summary
- sanitize nonce values pulled from requests before verifying

## Testing
- `php -l husfelag-bokhald/includes/security-functions.php`
- `php -l wordpress/wp-content/plugins/husfelag-bokhald/includes/security-functions.php`
- `php /tmp/test_nonce.php` *(failed: Error establishing a database connection)*
- `apt-get update` *(failed: 403  Forbidden [IP: 172.30.2.67 8080])*

------
https://chatgpt.com/codex/tasks/task_e_6894a4dc6ed88322a607bfa543fd314f