### PR TITLE
Add meeting minutes custom post type and upload page

### DIFF
--- a/husfelag-bokhald/husfelag-bokhald.php
+++ b/husfelag-bokhald/husfelag-bokhald.php
@@ -36,6 +36,7 @@ class HusfelagBokhald {
         register_deactivation_hook(__FILE__, array($this, 'deactivate'));
         
         add_action('init', array($this, 'init'));
+        add_action('init', array($this, 'register_document_cpt'));
         add_action('admin_menu', array($this, 'admin_menu'));
         add_action('admin_enqueue_scripts', array($this, 'admin_scripts'));
         add_action('wp_enqueue_scripts', array($this, 'frontend_scripts'));
@@ -61,6 +62,47 @@ class HusfelagBokhald {
      */
     public function init() {
         load_plugin_textdomain('husfelag-bokhald', false, dirname(plugin_basename(__FILE__)) . '/languages');
+    }
+
+    /**
+     * Skrá custom post type fyrir fundargerðir
+     */
+    public function register_document_cpt() {
+        $labels = array(
+            'name'               => __('Fundargerðir', 'husfelag-bokhald'),
+            'singular_name'      => __('Fundargerð', 'husfelag-bokhald'),
+            'add_new'            => __('Skrá nýja', 'husfelag-bokhald'),
+            'add_new_item'       => __('Skrá nýja fundargerð', 'husfelag-bokhald'),
+            'edit_item'          => __('Breyta fundargerð', 'husfelag-bokhald'),
+            'new_item'           => __('Ný fundargerð', 'husfelag-bokhald'),
+            'view_item'          => __('Skoða fundargerð', 'husfelag-bokhald'),
+            'search_items'       => __('Leita í fundargerðum', 'husfelag-bokhald'),
+            'not_found'          => __('Engar fundargerðir fundust', 'husfelag-bokhald'),
+            'not_found_in_trash' => __('Engar fundargerðir í rusli', 'husfelag-bokhald'),
+        );
+
+        $args = array(
+            'labels'             => $labels,
+            'public'             => false,
+            'show_ui'            => true,
+            'show_in_menu'       => false,
+            'supports'           => array('title', 'editor', 'revisions', 'thumbnail', 'custom-fields'),
+            'capability_type'    => 'post',
+            'map_meta_cap'       => false,
+            'capabilities'       => array(
+                'publish_posts'       => 'manage_options',
+                'edit_posts'          => 'manage_options',
+                'edit_others_posts'   => 'manage_options',
+                'delete_posts'        => 'manage_options',
+                'delete_others_posts' => 'manage_options',
+                'read_private_posts'  => 'manage_options',
+                'edit_post'           => 'manage_options',
+                'delete_post'         => 'manage_options',
+                'read_post'           => 'manage_options',
+            ),
+        );
+
+        register_post_type('hb_fundargerd', $args);
     }
     
     /**
@@ -187,6 +229,23 @@ class HusfelagBokhald {
             'husfelag-bank-api',
             array($this, 'admin_page_bank_api')
         );
+
+        add_submenu_page(
+            'husfelag-bokhald',
+            'Fundargerðir',
+            'Fundargerðir',
+            'manage_options',
+            'edit.php?post_type=hb_fundargerd'
+        );
+
+        add_submenu_page(
+            'husfelag-bokhald',
+            'Skrá fundargerð',
+            'Skrá fundargerð',
+            'manage_options',
+            'husfelag-fundargerdir',
+            array($this, 'admin_page_fundargerdir')
+        );
     }
     
     /**
@@ -251,6 +310,13 @@ class HusfelagBokhald {
      */
     public function admin_page_bank_api() {
         include HB_PLUGIN_PATH . 'includes/admin-bank-api.php';
+    }
+
+    /**
+     * Fundargerðir síða
+     */
+    public function admin_page_fundargerdir() {
+        include HB_PLUGIN_PATH . 'includes/admin-fundargerdir.php';
     }
 }
 

--- a/husfelag-bokhald/includes/admin-fundargerdir.php
+++ b/husfelag-bokhald/includes/admin-fundargerdir.php
@@ -1,0 +1,52 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!current_user_can('manage_options')) {
+    wp_die(__('Óheimill aðgangur', 'husfelag-bokhald'));
+}
+
+if (isset($_POST['hb_upload_fundargerd']) && check_admin_referer('hb_upload_fundargerd', 'hb_nonce')) {
+    $title = sanitize_text_field($_POST['fundargerd_title']);
+
+    $post_id = wp_insert_post(array(
+        'post_title'  => $title,
+        'post_type'   => 'hb_fundargerd',
+        'post_status' => 'publish'
+    ));
+
+    if (!is_wp_error($post_id) && !empty($_FILES['fundargerd_file']['name'])) {
+        require_once ABSPATH . 'wp-admin/includes/file.php';
+        require_once ABSPATH . 'wp-admin/includes/media.php';
+        require_once ABSPATH . 'wp-admin/includes/image.php';
+
+        $attachment_id = media_handle_upload('fundargerd_file', $post_id);
+
+        if (!is_wp_error($attachment_id)) {
+            $url = wp_get_attachment_url($attachment_id);
+            update_post_meta($post_id, 'document_url', esc_url_raw($url));
+            echo '<div class="notice notice-success"><p>' . __('Fundargerð skráð', 'husfelag-bokhald') . '</p></div>';
+        } else {
+            echo '<div class="notice notice-error"><p>' . __('Villa við skráningu skráar', 'husfelag-bokhald') . '</p></div>';
+        }
+    }
+}
+?>
+<div class="wrap">
+    <h1><?php _e('Hlaða upp fundargerð', 'husfelag-bokhald'); ?></h1>
+    <form method="post" enctype="multipart/form-data">
+        <?php wp_nonce_field('hb_upload_fundargerd', 'hb_nonce'); ?>
+        <table class="form-table">
+            <tr>
+                <th><label for="fundargerd_title"><?php _e('Titill', 'husfelag-bokhald'); ?></label></th>
+                <td><input type="text" id="fundargerd_title" name="fundargerd_title" class="regular-text" required></td>
+            </tr>
+            <tr>
+                <th><label for="fundargerd_file"><?php _e('Skjal', 'husfelag-bokhald'); ?></label></th>
+                <td><input type="file" id="fundargerd_file" name="fundargerd_file" accept=".pdf,.doc,.docx" required></td>
+            </tr>
+        </table>
+        <?php submit_button(__('Skrá fundargerð', 'husfelag-bokhald'), 'primary', 'hb_upload_fundargerd'); ?>
+    </form>
+</div>


### PR DESCRIPTION
## Summary
- add `hb_fundargerd` custom post type for meeting minutes with manage_options capability
- expose meeting minutes in plugin menu and provide upload page
- allow admins to upload PDF/Doc files and attach them to meeting minutes posts

## Testing
- `php -l husfelag-bokhald/husfelag-bokhald.php`
- `php -l husfelag-bokhald/includes/admin-fundargerdir.php`


------
https://chatgpt.com/codex/tasks/task_e_6894a72d255083228778945d33bf6743